### PR TITLE
install certificates when building image

### DIFF
--- a/cmd/netbox-ip-controller/Dockerfile
+++ b/cmd/netbox-ip-controller/Dockerfile
@@ -1,3 +1,7 @@
 FROM debian:bullseye
+
+RUN apt-get update && apt-get install -y ca-certificates
+
 ADD netbox-ip-controller /bin/netbox-ip-controller
+
 ENTRYPOINT ["/bin/netbox-ip-controller"]


### PR DESCRIPTION
Bare debian image doesn't include any certs, so adding them.