### PR TITLE
fix duplication of ips in netbox

### DIFF
--- a/cmd/netbox-ip-controller/root.go
+++ b/cmd/netbox-ip-controller/root.go
@@ -351,7 +351,10 @@ func run(ctx context.Context, globalCfg *globalConfig, cfg *rootConfig) error {
 
 	controllers := make(map[string]ctrl.Controller)
 
-	netboxController, err := netboxipctrl.New(ctrl.WithNetBoxClient(netboxClient))
+	netboxController, err := netboxipctrl.New(
+		ctrl.WithLogger(logger),
+		ctrl.WithNetBoxClient(netboxClient),
+	)
 	if err != nil {
 		return fmt.Errorf("initializing netbox controller: %q", err)
 	}

--- a/internal/controller/pod/pod_test.go
+++ b/internal/controller/pod/pod_test.go
@@ -101,6 +101,7 @@ func TestReconcile(t *testing.T) {
 					Controller:         pointer.Bool(true),
 					BlockOwnerDeletion: pointer.Bool(true),
 				}},
+				Finalizers: []string{netboxctrl.IPFinalizer},
 			},
 			Spec: v1beta1.NetBoxIPSpec{
 				Address: netip.AddrFrom4([4]byte{192, 168, 0, 1}),
@@ -218,6 +219,7 @@ func TestReconcile(t *testing.T) {
 					Controller:         pointer.Bool(true),
 					BlockOwnerDeletion: pointer.Bool(true),
 				}},
+				Finalizers: []string{netboxctrl.IPFinalizer},
 			},
 			Spec: v1beta1.NetBoxIPSpec{
 				Address: netip.AddrFrom4([4]byte{192, 168, 0, 1}),
@@ -314,6 +316,7 @@ func TestReconcile(t *testing.T) {
 					Controller:         pointer.Bool(true),
 					BlockOwnerDeletion: pointer.Bool(true),
 				}},
+				Finalizers: []string{netboxctrl.IPFinalizer},
 			},
 			Spec: v1beta1.NetBoxIPSpec{
 				Address: netip.AddrFrom4([4]byte{192, 168, 0, 1}),
@@ -431,6 +434,7 @@ func TestReconcileDualStack(t *testing.T) {
 					Controller:         pointer.Bool(true),
 					BlockOwnerDeletion: pointer.Bool(true),
 				}},
+				Finalizers: []string{netboxctrl.IPFinalizer},
 			},
 			Spec: v1beta1.NetBoxIPSpec{
 				Address: netip.AddrFrom4([4]byte{192, 168, 0, 1}),
@@ -480,6 +484,7 @@ func TestReconcileDualStack(t *testing.T) {
 					Controller:         pointer.Bool(true),
 					BlockOwnerDeletion: pointer.Bool(true),
 				}},
+				Finalizers: []string{netboxctrl.IPFinalizer},
 			},
 			Spec: v1beta1.NetBoxIPSpec{
 				Address: netip.AddrFrom16([16]byte{0, 1, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3}),
@@ -527,6 +532,7 @@ func TestReconcileDualStack(t *testing.T) {
 					Controller:         pointer.Bool(true),
 					BlockOwnerDeletion: pointer.Bool(true),
 				}},
+				Finalizers: []string{netboxctrl.IPFinalizer},
 			},
 			Spec: v1beta1.NetBoxIPSpec{
 				Address: netip.AddrFrom4([4]byte{192, 168, 0, 1}),
@@ -555,6 +561,7 @@ func TestReconcileDualStack(t *testing.T) {
 					Controller:         pointer.Bool(true),
 					BlockOwnerDeletion: pointer.Bool(true),
 				}},
+				Finalizers: []string{netboxctrl.IPFinalizer},
 			},
 			Spec: v1beta1.NetBoxIPSpec{
 				Address: netip.AddrFrom16([16]byte{0, 1, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3}),
@@ -696,7 +703,7 @@ func TestReconcileDualStack(t *testing.T) {
 					APIVersion: v1beta1.SchemeGroupVersion.String(),
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("pod-%sipv6", podUID),
+					Name:      fmt.Sprintf("pod-%s-ipv6", podUID),
 					Namespace: namespace,
 					Labels:    map[string]string{netboxctrl.NameLabel: name},
 					OwnerReferences: []metav1.OwnerReference{{
@@ -869,6 +876,7 @@ func TestReconcileDualStack(t *testing.T) {
 					Controller:         pointer.Bool(true),
 					BlockOwnerDeletion: pointer.Bool(true),
 				}},
+				Finalizers: []string{netboxctrl.IPFinalizer},
 			},
 			Spec: v1beta1.NetBoxIPSpec{
 				Address: netip.AddrFrom4([4]byte{192, 168, 0, 2}),
@@ -897,6 +905,7 @@ func TestReconcileDualStack(t *testing.T) {
 					Controller:         pointer.Bool(true),
 					BlockOwnerDeletion: pointer.Bool(true),
 				}},
+				Finalizers: []string{netboxctrl.IPFinalizer},
 			},
 			Spec: v1beta1.NetBoxIPSpec{
 				Address: netip.AddrFrom16([16]byte{0, 1, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4}),

--- a/internal/controller/service/service_test.go
+++ b/internal/controller/service/service_test.go
@@ -103,6 +103,7 @@ func TestReconcile(t *testing.T) {
 					Controller:         pointer.Bool(true),
 					BlockOwnerDeletion: pointer.Bool(true),
 				}},
+				Finalizers: []string{netboxctrl.IPFinalizer},
 			},
 			Spec: v1beta1.NetBoxIPSpec{
 				Address: netip.AddrFrom4([4]byte{192, 168, 0, 1}),
@@ -252,6 +253,7 @@ func TestReconcile(t *testing.T) {
 					Controller:         pointer.Bool(true),
 					BlockOwnerDeletion: pointer.Bool(true),
 				}},
+				Finalizers: []string{netboxctrl.IPFinalizer},
 			},
 			Spec: v1beta1.NetBoxIPSpec{
 				Address: netip.AddrFrom4([4]byte{192, 168, 0, 1}),
@@ -303,6 +305,7 @@ func TestReconcile(t *testing.T) {
 					Controller:         pointer.Bool(true),
 					BlockOwnerDeletion: pointer.Bool(true),
 				}},
+				Finalizers: []string{netboxctrl.IPFinalizer},
 			},
 			Spec: v1beta1.NetBoxIPSpec{
 				Address: netip.AddrFrom4([4]byte{192, 168, 0, 1}),
@@ -422,6 +425,7 @@ func TestReconcileDualStack(t *testing.T) {
 					Controller:         pointer.Bool(true),
 					BlockOwnerDeletion: pointer.Bool(true),
 				}},
+				Finalizers: []string{netboxctrl.IPFinalizer},
 			},
 			Spec: v1beta1.NetBoxIPSpec{
 				Address: netip.AddrFrom4([4]byte{192, 168, 0, 1}),
@@ -473,6 +477,7 @@ func TestReconcileDualStack(t *testing.T) {
 					Controller:         pointer.Bool(true),
 					BlockOwnerDeletion: pointer.Bool(true),
 				}},
+				Finalizers: []string{netboxctrl.IPFinalizer},
 			},
 			Spec: v1beta1.NetBoxIPSpec{
 				Address: netip.AddrFrom16([16]byte{0, 1, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3}),
@@ -522,6 +527,7 @@ func TestReconcileDualStack(t *testing.T) {
 					Controller:         pointer.Bool(true),
 					BlockOwnerDeletion: pointer.Bool(true),
 				}},
+				Finalizers: []string{netboxctrl.IPFinalizer},
 			},
 			Spec: v1beta1.NetBoxIPSpec{
 				Address: netip.AddrFrom4([4]byte{192, 168, 0, 1}),
@@ -550,6 +556,7 @@ func TestReconcileDualStack(t *testing.T) {
 					Controller:         pointer.Bool(true),
 					BlockOwnerDeletion: pointer.Bool(true),
 				}},
+				Finalizers: []string{netboxctrl.IPFinalizer},
 			},
 			Spec: v1beta1.NetBoxIPSpec{
 				Address: netip.AddrFrom16([16]byte{0, 1, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3}),
@@ -867,6 +874,7 @@ func TestReconcileDualStack(t *testing.T) {
 					Controller:         pointer.Bool(true),
 					BlockOwnerDeletion: pointer.Bool(true),
 				}},
+				Finalizers: []string{netboxctrl.IPFinalizer},
 			},
 			Spec: v1beta1.NetBoxIPSpec{
 				Address: netip.AddrFrom4([4]byte{192, 168, 0, 2}),
@@ -895,6 +903,7 @@ func TestReconcileDualStack(t *testing.T) {
 					Controller:         pointer.Bool(true),
 					BlockOwnerDeletion: pointer.Bool(true),
 				}},
+				Finalizers: []string{netboxctrl.IPFinalizer},
 			},
 			Spec: v1beta1.NetBoxIPSpec{
 				Address: netip.AddrFrom16([16]byte{0, 1, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4}),

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -103,6 +103,7 @@ func CreateNetBoxIPs(ips []string, config NetBoxIPConfig) (*IPs, error) {
 				Labels: map[string]string{
 					netboxctrl.NameLabel: config.Object.GetName(),
 				},
+				Finalizers: []string{netboxctrl.IPFinalizer},
 			},
 			Spec: v1beta1.NetBoxIPSpec{
 				Address:     addr,
@@ -185,6 +186,7 @@ func UpsertNetBoxIP(ctx context.Context, kubeClient client.Client, ll *log.Logge
 
 		existingIP.Spec = ip.Spec
 		existingIP.OwnerReferences = ip.OwnerReferences
+		existingIP.Finalizers = ip.Finalizers
 		existingIP.Labels = ip.Labels
 		if err := kubeClient.Update(ctx, &existingIP); err != nil {
 			return fmt.Errorf("updating netboxip: %w", err)


### PR DESCRIPTION
Major fix: adding the finalizer to netboxip objects right upon creation. This :crossed_fingers: should get rid of the small gap in time between when a netboxip is created and when the controller updates it by adding the finalizer.

A comple smaller things:
- passing logger to the netboxip controller
- avoiding unnecessary work and potential errors due to upserting a netboxip for a pod that shouldn't have an IP in the first place (such as a completed pod)