### PR TITLE
use pod/service-publish-labels flags to limit which IPs get exported

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ with dashes (`-`) replaced with underscores (`_`).
 `cluster-domain` | `cluster.local` | Domain name of the cluster. Optional.
 `pod-ip-tags` | `kubernetes,k8s-pod` | Comma-separated list of tags to add to pod IPs in NetBox. Any tags that don't yet exist will be created. Optional.
 `service-ip-tags` | `kubernetes,k8s-service` | Comma-separated list of tags to add to service IPs in NetBox. Any tags that don't yet exist will be created. Optional.
-`pod-publish-labels` | `app` | Comma-separated list of kubernetes pod labels to be added to the IP description in NetBox in `label: label_value` format. Only the IPs of the pods that have one of these labels set will be exported. Optional. 
-`service-publish-labels` | `app` | Comma-separated list of kubernetes service labels to be added to the IP description in NetBox in `label: label_value` format. Only the IPs of the services that have one of these labels set will be exported. Optional. 
+`pod-publish-labels` | `app` | Comma-separated list of kubernetes pod labels to be added to the IP description in NetBox in `label: label_value` format. Only the IPs of the pods that have at least one of these labels set will be exported. Set to an empty list if you do not want pod IPs exported. Optional. 
+`service-publish-labels` | `app` | Comma-separated list of kubernetes service labels to be added to the IP description in NetBox in `label: label_value` format. Only the IPs of the services that have at least one of these labels set will be exported. Set to an empty list if you do not want service IPs exported. Optional. 
 `dual-stack-ip` | `false` | Enables registering both IPv4 and IPv6 addresses of pods and services where applicable in dual stack clusters. Optional.
 `ready-check-addr` | `:5001` | Sets the address that the controller manager will bind to for serving the ready check endpoint. Can be a full TCP address or only a port (e.g. `:5001`). Optional. 
 `debug` | `false` | Turns on debug logging. Optional.
@@ -48,6 +48,9 @@ targets individually, which can be helpful for leaving the netbox environment up
 ## Install
 
 A sample deployment for running in-cluster can be found at [docs/example-deployment.yml](docs/example-deployment.yml).
+**Note** that the controller will only export the IPs of the pods and services that have at least one of `--pod-publish-labels` or
+`--service-publish-labels` respectively set.
+
 If you have RBAC enabled in the cluster, you will also need [docs/rbac.yml](/docs/rbac.yml).
 
 Docker images are automatically built and distributed for each release and can be found at `digitalocean/netbox-ip-controller:<tag>`.

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ with dashes (`-`) replaced with underscores (`_`).
 `cluster-domain` | `cluster.local` | Domain name of the cluster. Optional.
 `pod-ip-tags` | `kubernetes,k8s-pod` | Comma-separated list of tags to add to pod IPs in NetBox. Any tags that don't yet exist will be created. Optional.
 `service-ip-tags` | `kubernetes,k8s-service` | Comma-separated list of tags to add to service IPs in NetBox. Any tags that don't yet exist will be created. Optional.
-`pod-publish-labels` | `app` | Comma-separated list of kubernetes pod labels to be added to the IP description in NetBox in `label: label_value` format. Optional. 
-`service-publish-labels` | `app` | Comma-separated list of kubernetes service labels to be added to the IP description in NetBox in `label: label_value` format. Optional. 
+`pod-publish-labels` | `app` | Comma-separated list of kubernetes pod labels to be added to the IP description in NetBox in `label: label_value` format. Only the IPs of the pods that have one of these labels set will be exported. Optional. 
+`service-publish-labels` | `app` | Comma-separated list of kubernetes service labels to be added to the IP description in NetBox in `label: label_value` format. Only the IPs of the services that have one of these labels set will be exported. Optional. 
 `dual-stack-ip` | `false` | Enables registering both IPv4 and IPv6 addresses of pods and services where applicable in dual stack clusters. Optional.
 `ready-check-addr` | `:5001` | Sets the address that the controller manager will bind to for serving the ready check endpoint. Can be a full TCP address or only a port (e.g. `:5001`). Optional. 
 `debug` | `false` | Turns on debug logging. Optional.

--- a/docs/example-deployment.yml
+++ b/docs/example-deployment.yml
@@ -31,6 +31,10 @@ spec:
             secretKeyRef:
               key: netbox-token
               name: netbox-ip-controller
+        - name: POD_PUBLISH_LABELS
+          value: app,k8s-app
+        - name: SERVICE_PUBLISH_LABELS
+          value: app,k8s-app
 ---
 apiVersion: v1
 kind: Secret

--- a/internal/controller/pod/pod_test.go
+++ b/internal/controller/pod/pod_test.go
@@ -173,6 +173,25 @@ func TestReconcile(t *testing.T) {
 		},
 		expectedNetBoxIP: nil,
 	}, {
+		name: "without publish labels",
+		existingPod: &corev1.Pod{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Pod",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				UID:       types.UID(podUID),
+				Labels:    map[string]string{"wrong_label": "foo"},
+			},
+			Status: corev1.PodStatus{
+				PodIP: "192.168.0.1",
+			},
+		},
+		existingNetBoxIP: nil,
+		expectedNetBoxIP: nil,
+	}, {
 		name: "fix NetBoxIP that got out of sync",
 		existingPod: &corev1.Pod{
 			TypeMeta: metav1.TypeMeta{

--- a/internal/controller/service/service_test.go
+++ b/internal/controller/service/service_test.go
@@ -205,6 +205,27 @@ func TestReconcile(t *testing.T) {
 		},
 		expectedNetBoxIP: nil,
 	}, {
+		name: "without publish labels",
+		existingService: &corev1.Service{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Service",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				UID:       types.UID(serviceUID),
+				Labels:    map[string]string{"wrong_label": "foo"},
+			},
+			Spec: corev1.ServiceSpec{
+				Ports:     []corev1.ServicePort{{Port: 8080}},
+				Type:      corev1.ServiceTypeClusterIP,
+				ClusterIP: "192.168.0.1",
+			},
+		},
+		existingNetBoxIP: nil,
+		expectedNetBoxIP: nil,
+	}, {
 		name: "fix NetBoxIP that got out of sync",
 		existingService: &corev1.Service{
 			TypeMeta: metav1.TypeMeta{

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -200,3 +200,14 @@ func UpsertNetBoxIP(ctx context.Context, kubeClient client.Client, ll *log.Logge
 		return nil
 	})
 }
+
+// HasPublishLabels checks if the given object labels contain any of the publish labels
+// (i.e. labels that indicate its IP should be exported).
+func HasPublishLabels(publishLabels map[string]bool, objLabels map[string]string) bool {
+	for label := range publishLabels {
+		if _, ok := objLabels[label]; ok {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
An option to limit which IPs get exported comes in handly, e.g., for avoiding exporting job pod IPs, daemonset IPs etc.
Creating a whole separate flag (or flags, one for pods and one for services) for this purpose whould make the configuration confusing (too many knobs), so, decided to extend the responsibility of the existing `pod/service-publish-labels` flags.