### PR TITLE
DELI-5255: added metrics for failed requests to NetBox Server

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -26,26 +26,22 @@ import (
 // exposed by the kubernetes controller manager
 func init() {
 	kubemetrics.Registry.MustRegister(netboxTotalRequests)
-	kubemetrics.Registry.MustRegister(netboxFailedRequests)
 }
 
 var (
-	netboxTotalRequests = prometheus.NewCounter(prometheus.CounterOpts{
+	netboxTotalRequests = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "netbox_requests_total",
 		Help: "Total number of requests sent to the NetBox API server",
-	})
-	netboxFailedRequests = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "netbox_failed_requests_total",
-		Help: "Total number of failed requests to NetBox Server",
-	})
+	},
+		[]string{"status"},
+	)
 )
 
 // IncrementNetboxRequestsTotal increments the netbox_total_requests metric
-func IncrementNetboxRequestsTotal() {
-	netboxTotalRequests.Inc()
-}
-
-// IncrementFailedNetboxRequestsTotal increments the netbox_update_record_error_count metric
-func IncrementFailedNetboxRequestsTotal() {
-	netboxFailedRequests.Inc()
+func IncrementNetboxRequestsTotal(isSuccess bool) {
+	if isSuccess {
+		netboxTotalRequests.WithLabelValues("success").Inc()
+	} else {
+		netboxTotalRequests.WithLabelValues("failure").Inc()
+	}
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -26,6 +26,7 @@ import (
 // exposed by the kubernetes controller manager
 func init() {
 	kubemetrics.Registry.MustRegister(netboxTotalRequests)
+	kubemetrics.Registry.MustRegister(netboxFailedRequests)
 }
 
 var (
@@ -33,9 +34,18 @@ var (
 		Name: "netbox_requests_total",
 		Help: "Total number of requests sent to the NetBox API server",
 	})
+	netboxFailedRequests = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "netbox_failed_requests_total",
+		Help: "Total number of failed requests to NetBox Server",
+	})
 )
 
 // IncrementNetboxRequestsTotal increments the netbox_total_requests metric
 func IncrementNetboxRequestsTotal() {
 	netboxTotalRequests.Inc()
+}
+
+// IncrementFailedNetboxRequestsTotal increments the netbox_update_record_error_count metric
+func IncrementFailedNetboxRequestsTotal() {
+	netboxFailedRequests.Inc()
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -37,8 +37,8 @@ var (
 	)
 )
 
-// IncrementNetboxRequestsTotal increments the netbox_total_requests metric
-func IncrementNetboxRequestsTotal(isSuccess bool) {
+// IncrementNetboxRequests increments the netbox_total_requests metric with success/failure labels
+func IncrementNetboxRequests(isSuccess bool) {
 	if isSuccess {
 		netboxTotalRequests.WithLabelValues("success").Inc()
 	} else {

--- a/internal/netbox/client.go
+++ b/internal/netbox/client.go
@@ -386,17 +386,17 @@ func (c *client) executeRequest(ctx context.Context, url string, method string, 
 
 	}
 	if responseErr != nil {
-		metrics.IncrementNetboxRequestsTotal(false)
+		metrics.IncrementNetboxRequests(false)
 		return nil, responseErr
 	}
 	defer res.Body.Close()
 
 	if err := httpErrorFrom(res); err != nil {
-		metrics.IncrementNetboxRequestsTotal(false)
+		metrics.IncrementNetboxRequests(false)
 		return nil, err
 	}
 
-	metrics.IncrementNetboxRequestsTotal(true)
+	metrics.IncrementNetboxRequests(true)
 
 	data, err := io.ReadAll(io.LimitReader(res.Body, responseBodySizeLimit))
 	if err != nil {

--- a/internal/netbox/client.go
+++ b/internal/netbox/client.go
@@ -386,6 +386,7 @@ func (c *client) executeRequest(ctx context.Context, url string, method string, 
 
 	}
 	if responseErr != nil {
+		metrics.IncrementFailedNetboxRequestsTotal()
 		return nil, responseErr
 	}
 	defer res.Body.Close()
@@ -393,6 +394,7 @@ func (c *client) executeRequest(ctx context.Context, url string, method string, 
 	metrics.IncrementNetboxRequestsTotal()
 
 	if err := httpErrorFrom(res); err != nil {
+		metrics.IncrementFailedNetboxRequestsTotal()
 		return nil, err
 	}
 

--- a/internal/netbox/client.go
+++ b/internal/netbox/client.go
@@ -386,17 +386,17 @@ func (c *client) executeRequest(ctx context.Context, url string, method string, 
 
 	}
 	if responseErr != nil {
-		metrics.IncrementFailedNetboxRequestsTotal()
+		metrics.IncrementNetboxRequestsTotal(false)
 		return nil, responseErr
 	}
 	defer res.Body.Close()
 
-	metrics.IncrementNetboxRequestsTotal()
-
 	if err := httpErrorFrom(res); err != nil {
-		metrics.IncrementFailedNetboxRequestsTotal()
+		metrics.IncrementNetboxRequestsTotal(false)
 		return nil, err
 	}
+
+	metrics.IncrementNetboxRequestsTotal(true)
 
 	data, err := io.ReadAll(io.LimitReader(res.Body, responseBodySizeLimit))
 	if err != nil {


### PR DESCRIPTION
[DELI-5255](https://jira.internal.digitalocean.com/browse/DELI-5255) : metrics for failed requests to Netbox Server