### PR TITLE
Fix kubectl download path

### DIFF
--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN wget -qO /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v${K8S_VERSION}/bin/linux/amd64/kubectl && \
+RUN wget -qO /usr/local/bin/kubectl https://dl.k8s.io/release/v${K8S_VERSION}/bin/linux/amd64/kubectl && \
     chmod +x /usr/local/bin/kubectl
 
 RUN cd /var/tmp && \


### PR DESCRIPTION
The path for installing kubectl has changed from `storage.googleapis.com` to `dl.k8s.io`.
Reference: https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/